### PR TITLE
Faster spat cov annotation

### DIFF
--- a/R/specifySpecies.R
+++ b/R/specifySpecies.R
@@ -1857,7 +1857,10 @@ specifySpecies$set('private', 'spatialCovariates', function(spatialCovariates) {
   #if (class(spatialCovariates) %in% c('RasterLayer', 'RasterBrick', 'RasterStack')) objSpat <- terra::rast(spatialCovariates)
   
   if (inherits(spatialCovariates, 'Spatial')) covsClass <- sapply(spatialCovariates@data, class)
-  else if (inherits(spatialCovariates, 'SpatRaster')) covsClass <- sapply(as.data.frame(spatialCovariates), class)
+  #   else if (inherits(spatialCovariates, 'SpatRaster')) covsClass <- sapply(seq(spatialCovariates[1]), function(x){
+  #         class(unlist(spatialCovariates[[x]][,1]))
+  #     }) |> setNames(names(spatialCovariates))
+  else if (inherits(spatialCovariates, 'SpatRaster')) covsClass <- sapply(spatialCovariates[1], class)
   else covsClass <- sapply(as.data.frame(terra::rast(spatialCovariates)), class)
   
   

--- a/R/specifySpecies.R
+++ b/R/specifySpecies.R
@@ -1967,3 +1967,11 @@ specifySpecies$set('public', 'spatialFields', list(sharedField = list(),
                                                 datasetFields = list(),
                                                 biasFields = list(),
                                                 speciesFields = list()))
+nearestValue <- function(pts, r,...) {
+  # Convert SpatRaster to points
+  rxy <- as.data.frame(r, xy = TRUE, na.rm = TRUE)
+  # Get the nearest raster cell index for each point
+  ind <- FNN::knnx.index(rxy[, c("x", "y")], pts, k = 1, ...)[, 1]
+  # Return the raster values corresponding to the nearest points
+  rxy[ind, 3]
+}

--- a/R/specifySpecies.R
+++ b/R/specifySpecies.R
@@ -1674,86 +1674,158 @@ specifySpecies$set('private', 'addData', function(dataList, responseCounts, resp
   ##MAKE THIS A FUNCTION TOO
   if (!is.null(private$spatcovsNames)) {
     
-    for (data in names(pointData$Data)) {
-      
-      for (species in 1:length(pointData$Data[[data]])) {
-        
-        for (cov in private$spatcovsNames) {
-          
-          if (!is.null(private$biasFormula)) {
-
-            if (cov %in% labels(terms(private$biasFormula))) covIndex <- cov
-          else 
-            if (!is.null(private$speciesName) && private$speciesEnvironment) covIndex <- paste0(pointData$SpeciesInData[[data]][species],'_', cov)
-            else covIndex <- cov
-          }
-          else
-            if (!is.null(private$speciesName) && private$speciesEnvironment) covIndex <- paste0(pointData$SpeciesInData[[data]][species],'_', cov)
-            else covIndex <- cov
-          
-          pointData$Data[[data]][[species]][[covIndex]] <- inlabru::eval_spatial(where = pointData$Data[[data]][[species]], 
-                                                                                 data = get('spatialcovariates', 
-                                                                                            envir = private$spatcovsEnv)[cov],
-                                                                                 layer = cov)
-          
-          if (any(is.na(pointData$Data[[data]][[species]][[covIndex]]))) {
-            
-            pointData$Data[[data]][[species]][[covIndex]] <- inlabru::bru_fill_missing(where = pointData$Data[[data]][[species]], 
-                                                                                       data = get('spatialcovariates', 
-                                                                                                  envir = private$spatcovsEnv)[cov],
-                                                                                       layer = cov,
-                                                                                       values = pointData$Data[[data]][[species]][[covIndex]])
-            
-          }
-          
-          
+    # identify columns in each dataframe in list
+    dataColNames <- lapply(pointData$Data, function(x) lapply(x, names))
+    # identify usage of spatial covariates in model
+    allCovs <- names(get('spatialcovariates',envir = private$spatcovsEnv))
+    biasCovs <- if(is.null(private$biasFormula)) NULL else labels(terms(private$biasFormula))
+    modelCovs <- allCovs[! allCovs %in% biasCovs]
+    # merge all data
+    fullGeom <- dplyr::bind_rows(lapply(pointData$Data, dplyr::bind_rows))
+    # annotate all environmental data
+    fullGeomCovs <- terra::extract(get('spatialcovariates',envir = private$spatcovsEnv), fullGeom, ID = FALSE)
+    # fill in missing values
+    if(any(is.na(fullGeomCovs))){
+      naRows <- lapply(fullGeomCovs, function(x) which(is.na(x)))  # identify missing rows
+      naCovs <- names(naRows)[sapply(naRows, length) > 0]  # identify covs with missing data
+      for(cov in naCovs){  # fill missing values for rows/covs using nearest neighbour 
+        fullGeomCovs[naRows[[cov]], cov] <- 
+          nearestValue(st_coordinates(fullGeom[naRows[[cov]],])[,c("X","Y")], 
+                       get('spatialcovariates', envir = private$spatcovsEnv)[cov])
+        # out <- inlabru::bru_fill_missing(where = fullGeom[naRows[[cov]],], 
+        #     data = get('spatialcovariates', 
+        #             envir = private$spatcovsEnv)[cov],
+        #     layer = cov,
+        #     values = rep(NA, length(naRows[[cov]])))
+      }
+    }
+    # combine with rest of data
+    fullGeom <- cbind(fullGeom, fullGeomCovs) 
+    # split by dataset 
+    split <- split(fullGeom, factor(fullGeom$._dataset_index_var_., levels = unique(fullGeom$._dataset_index_var_.)))
+    names(split) <- names(pointData$Data)
+    # split by species & update columns
+    split <- lapply(split, function(x){
+      # split by species name
+      xSplit <- split(x, factor(x$simpleScientificNameINDEX_VAR, levels = unique(x$simpleScientificNameINDEX_VAR)))
+      ds <- names(dataColNames)[x$._dataset_index_var_.[1]]
+      # for each species, update names of covariates
+      xSplit <- lapply(xSplit, function(x2){
+        # drop irrelevant occurence columns
+        colsKeep <- dataColNames[[ds]][[paste0(ds, "_", x2$simpleScientificNameINDEX_VAR[1])]]
+        x2 <- x2[,c(colsKeep, allCovs)]
+        # update cov names
+        if (!is.null(private$speciesName) && private$speciesEnvironment) {
+          dfNames <- names(x2)
+          dfNames[dfNames %in% modelCovs] <- paste0(x2$simpleScientificNameINDEX_VAR[1],'_', dfNames[dfNames %in% modelCovs])
+          # update cov names
+          names(x2) <- dfNames
         }
-        
-    
+        # return
+        return(x2)
+      })
+      # update list name
+      names(xSplit) <- names(dataColNames[[ds]])
+      # return
+      return(xSplit)
+    })
+    pointData$Data <- split
+    # annotate integration mesh
     if (!is.null(private$IPS)) {
-      
-      for (covIPS in private$spatcovsNames) {
-     
-        if (!is.null(private$biasFormula)) {
-          
-          if (covIPS %in% labels(terms(private$biasFormula))) covIPSindex <- covIPS
-          else 
-            if (!is.null(private$speciesName) && private$speciesEnvironment) covIPSindex <- paste0(pointData$SpeciesInData[[data]][species],'_', covIPS)
-            else covIPSindex <- covIPS
-        }
-        else
-          if (!is.null(private$speciesName) && private$speciesEnvironment) covIPSindex <- paste0(unique(unlist(private$speciesIn)), '_', covIPS)
-          else covIPSindex <- covIPS
-        
-        for (covADD in covIPSindex) {
-          
-          private$IPS[[covADD]] <- inlabru::eval_spatial(where =  private$IPS, 
-                                                         data = get('spatialcovariates', 
-                                                                    envir = private$spatcovsEnv)[covIPS],
-                                                         layer = covIPS
-          )
-          
-          if (any(is.na(private$IPS[[covADD]]))) {
-            
-            private$IPS[[covADD]] <- inlabru::bru_fill_missing(where = private$IPS, 
-                                                               data = get('spatialcovariates', 
-                                                                          envir = private$spatcovsEnv)[covIPS],
-                                                               layer = covIPS,
-                                                               values = private$IPS[[covADD]])
-            
-          }
-          
+      # annotate all environmental data
+      meshCovs <- terra::extract(get('spatialcovariates',envir = private$spatcovsEnv),
+                                 private$IPS, ID = FALSE)
+      # fill in missing values
+      if(any(is.na(meshCovs))){
+        naRows <- lapply(meshCovs, function(x) which(is.na(x)))  # identify missing rows
+        naCovs <- names(naRows)[sapply(naRows, length) > 0]  # identify covs with missing data
+        for(cov in naCovs){  # fill missing values for rows/covs using nearest neighbour 
+          meshCovs[naRows[[cov]], cov] <- 
+            nearestValue(st_coordinates(private$IPS[naRows[[cov]],])[,c("X","Y")], 
+                         get('spatialcovariates', envir = private$spatcovsEnv)[cov])
         }
         
         
       }
       
-      
-    }
-        
+      # define mesh cov names
+      if (!is.null(private$speciesName) && private$speciesEnvironment) {
+        # identify unique species
+        speciesIn <- unique(unlist(private$speciesIn))
+        # expand meshCovs
+        meshCovs <- meshCovs[c(biasCovs, rep(modelCovs, length(speciesIn)))]
+        # update names
+        names(meshCovs) <- c(biasCovs, paste0(rep(speciesIn, each = length(modelCovs)), "_", rep(modelCovs, length(speciesIn))))
       }
+      # combine 
+      private$IPS <- cbind(private$IPS, meshCovs)
     }
     
+    # for (data in names(pointData$Data)) {
+    
+    #   for (species in 1:length(pointData$Data[[data]])) {
+    
+    #     for (cov in private$spatcovsNames) {
+    
+    #       if (!is.null(private$biasFormula)) {
+    
+    #         if (cov %in% labels(terms(private$biasFormula))) covIndex <- cov
+    #         else 
+    #           if (!is.null(private$speciesName) && private$speciesEnvironment) covIndex <- paste0(pointData$SpeciesInData[[data]][species],'_', cov)
+    #           else covIndex <- cov
+    #       }
+    #       else
+    #         if (!is.null(private$speciesName) && private$speciesEnvironment) covIndex <- paste0(pointData$SpeciesInData[[data]][species],'_', cov)
+    #         else covIndex <- cov
+    #       pointData$Data[[data]][[species]][[covIndex]] <- 
+    #         inlabru::eval_spatial(where = pointData$Data[[data]][[species]], 
+    #             data = get('spatialcovariates', 
+    #                         envir = private$spatcovsEnv)[cov],
+    #             layer = cov)
+    #         if (any(is.na(pointData$Data[[data]][[species]][[covIndex]]))) {
+    #           pointData$Data[[data]][[species]][[covIndex]] <- 
+    #             inlabru::bru_fill_missing(where = pointData$Data[[data]][[species]], 
+    #                 data = get('spatialcovariates', 
+    #                         envir = private$spatcovsEnv)[cov],
+    #                 layer = cov,
+    #                 values = pointData$Data[[data]][[species]][[covIndex]])
+    
+    #         }
+    #     }
+    
+    #     if (!is.null(private$IPS)) {
+    #       for (covIPS in private$spatcovsNames) {
+    
+    #         if (!is.null(private$biasFormula)) {
+    
+    #           if (covIPS %in% labels(terms(private$biasFormula))) covIPSindex <- covIPS
+    #           else 
+    #             if (!is.null(private$speciesName) && private$speciesEnvironment) covIPSindex <- paste0(pointData$SpeciesInData[[data]][species],'_', covIPS)
+    #             else covIPSindex <- covIPS
+    #         }
+    #         else
+    #           if (!is.null(private$speciesName) && private$speciesEnvironment) covIPSindex <- paste0(unique(unlist(private$speciesIn)), '_', covIPS)
+    #           else covIPSindex <- covIPS
+    
+    #           for (covADD in covIPSindex) {
+    #             private$IPS[[covADD]] <- inlabru::eval_spatial(where =  private$IPS, 
+    #                                                            data = get('spatialcovariates', 
+    #                                                                       envir = private$spatcovsEnv)[covIPS],
+    #                                                            layer = covIPS
+    #             )
+    
+    #             if (any(is.na(private$IPS[[covADD]]))) {
+    #               private$IPS[[covADD]] <- inlabru::bru_fill_missing(where = private$IPS, 
+    #                                                                  data = get('spatialcovariates', 
+    #                                                                             envir = private$spatcovsEnv)[covIPS],
+    #                                                                  layer = covIPS,
+    #                                                                  values = private$IPS[[covADD]])
+    #             }
+    #           }
+    #       }
+    #     }
+    #   }
+    # }
   }
   
   


### PR DESCRIPTION
Three updates to speed up processing of environmental data:
1. apply 'class' on just the first row of covariate data instead of converting the whole spatRaster to a data.frame for getting class of covariate. 
2. annotate all environmental data covariates for all species and datasets simultaneously, then split into nested dataset-species lists. This is repeated for annotating covariate data at mesh nodes. This replaces the nested for loops, which were responsible for the very slow data preparation.
3. use custom nearestValue function based on FNN package to annotate covariates using nearest non-NA cell. this is significantly faster than inlabru::bru_fill_missing().

Note: I have only tested with locations as class sf and spatial covariates as class SpatRaster. Some edits may be required for legacy formats (i.e., raster & sp).

